### PR TITLE
autonext instead of next

### DIFF
--- a/source/voiceAPI/Subscription.ts
+++ b/source/voiceAPI/Subscription.ts
@@ -87,7 +87,7 @@ export class Subscription {
         });
         
         this.audioPlayer.on(AudioPlayerEvent.Error, () => {
-            this.audioPlayer.emit(AudioPlayerEvent.Next);
+            this.autonext();
         });
 
         this.audioPlayer.on(AudioPlayerEvent.Retry, () => {
@@ -95,7 +95,7 @@ export class Subscription {
         });
 
         this.audioPlayer.on(AudioPlayerEvent.Failed, () => {
-            this.audioPlayer.emit(AudioPlayerEvent.Next);
+            this.autonext();
         });
         
         // - - - 
@@ -159,8 +159,7 @@ export class Subscription {
             });
     
             this.tracklist.now.once(TrackStatus.AudioFailed, () => {
-                this.autonextTimeout = setTimeout(()=> {this.next();}, 10000);
-                this.musicDisplayerFullUpdate();
+                this.autonext();
             });            
         }
 
@@ -220,6 +219,12 @@ export class Subscription {
         this.tracklist.destroy();
         this.musicDisplayer.delete();
         Subscription.guildSubscriptions.delete(guildId);
+    }
+
+    private autonext() {
+        this.tracklist.now.updateFailStatus(true);
+        this.autonextTimeout = setTimeout(()=> {this.next();}, 10000);
+        this.musicDisplayerFullUpdate();
     }
 
     private clearAutonextTimeout() {

--- a/source/voiceAPI/Track.ts
+++ b/source/voiceAPI/Track.ts
@@ -77,7 +77,7 @@ export class Track extends EventEmitter {
         }
     }
 
-    private updateFailStatus(hasFail: boolean) {
+    updateFailStatus(hasFail: boolean) {
         this.failed = hasFail;
         this.data.audioFailed = hasFail;
     }


### PR DESCRIPTION
Replace the calls to audioPlayerNext on error and failed by autonext() which will show an error message to the user. Should clear issue #6  user-wise

Adding it to the winter cleaning branch for easier testing